### PR TITLE
Clear our audio graph on instrument change

### DIFF
--- a/script.js
+++ b/script.js
@@ -238,10 +238,12 @@ function updateInstrument(e) {
     updatePresets();
   }
   var preset = presetEl.value === '' ? undefined : presetEl.value;
+  if (instrument != undefined) instrument.clear();
   instrument = window[instrumentEl.value](preset);
   instrument.connect( reverb, Number(instRevEl.value) );
   instrument.connect( delay, Number(instDelayEl.value) );
 
+  if (previewInstrument != undefined) previewInstrument.clear();
   previewInstrument = window[instrumentEl.value](preset);
   if(isPlaying) {
     play();


### PR DESCRIPTION
@charlieroberts
"synths aren't getting deleted when you change sounds / presets
so you wind up getting these giant audio graphs running over time"